### PR TITLE
feat(build): add jq to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN         curl -#L -o webhook.tar.gz https://api.github.com/repos/adnanh/webho
             go build -ldflags="-s -w" -o /usr/local/bin/webhook
 
 FROM        alpine:3.17.1
-RUN         apk add --update --no-cache curl tini tzdata
+RUN         apk add --update --no-cache curl tini tzdata jq
 COPY        --from=BUILD_IMAGE /usr/local/bin/webhook /usr/local/bin/webhook
 WORKDIR     /config
 EXPOSE      9000


### PR DESCRIPTION
Adds [`jq`](https://stedolan.github.io/jq/tutorial/), which is super useful to parse JSON from webhook requests, to the Docker image.